### PR TITLE
Control Log json communications with vscode-client tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,32 @@
           "type": "string",
           "description": "Binary name or path to language server",
           "default": ""
+        },
+        "vala.trace.server": {
+          "scope": "window",
+          "type": "object",
+          "description": "Traces the communication between VS Code and the language server.",
+          "properties": {
+            "verbosity": {
+              "type": "string",
+              "description": "Controls the verbosity of the trace.",
+              "enum": [
+                "off",
+                "message",
+                "verbose"
+              ],
+              "default": "off"
+            },
+            "format": {
+              "type": "string",
+              "description": "Controls the output format of the trace.",
+              "enum": [
+                "text",
+                "json"
+              ],
+              "default": "text"
+            }
+          }
         }
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -40,15 +40,14 @@ export class ValaLanguageClient {
                 options: {
                     env: {
                         ...process.env,
-                        G_MESSAGES_DEBUG: 'all',
-                        JSONRPC_DEBUG: 1
+                        G_MESSAGES_DEBUG: 'all'
                     }
                 },
                 transport: TransportKind.stdio
             }
         };
 
-        this.ls = new LanguageClient('Vala Language Server', serverOptions, clientOptions)
+        this.ls = new LanguageClient('vala', 'Vala Language Server', serverOptions, clientOptions)
 
         this.ls.start()
     }


### PR DESCRIPTION
Allow to control wheter or not you want to see the json messages between client and server

**NOTE**: I set the client id as vala (`vala.trace.server`), but there're other settings using vls as id (`vls.execPath`). 

fixes #6 